### PR TITLE
smart contract fixes

### DIFF
--- a/contracts/BatchTransfer.sol
+++ b/contracts/BatchTransfer.sol
@@ -1,19 +1,42 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+
 interface IERC721 {
     function safeTransferFrom(address _from, address _to, uint256 _tokenId) external;
+    function getApproved(uint256 _tokenId) external view returns (address);
+
 }
 
-contract BatchTransfer {
+contract BatchTransfer is Ownable {
 
     event TransferSuccessfull(address indexed _from, IERC721 indexed _collection, address indexed _to);
 
-    function bulkTransfer(address _from, IERC721 _collection, address _to, uint256[] memory _tokenIds) external {
+    function bulkTransfer(address _from, IERC721 _collection, address _to, uint256[] memory _tokenIds, uint256 _limit) external onlyOwner {
         for (uint256 i = 0; i < _tokenIds.length; i++) {
-            _collection.safeTransferFrom(_from, _to, _tokenIds[i]);
+         require(_limit > 0, "Limit must be greater than 0");
+        require(_tokenIds.length <= _limit, "Number of tokens to transfer exceeds limit");
+        require(_collection.getApproved(_tokenIds[i]) == address(this), "Contract not approved for transfer");
+        _collection.safeTransferFrom(_from, _to, _tokenIds[i]);
         }
 
         emit TransferSuccessfull(_from, _collection, _to);
     }
+
+
+        function withdraw(IERC721 _collection, address _to, uint256[] memory _tokenIds) external onlyOwner {
+            for (uint256 i = 0; i < _tokenIds.length; i++) {
+                _collection.safeTransferFrom(address(this), _to, _tokenIds[i]);
+            }
+        }
+
+        
+
+        
+
+     
+
+
 }


### PR DESCRIPTION
- Added a check to verify if the contract address has the necessary approval for each token transfer.

-  Implementing some form of access control or permission management to limit who can call the bulkTransfer function.

- Considering the gas cost of the bulkTransfer function, as it can become expensive for a large number of tokens.

- added a function to withdraw tokens from the contract in case the contract holds tokens that need to be transferred to another address. This function can be useful when the contract is no longer needed or when tokens need to be returned to their original owners

- There is no limit on the number of tokens that can be transferred in a single call to the bulkTransfer function. This could lead to performance issues if someone tries to transfer a large number of tokens in a single call. To prevent this, added a limit on the number of tokens that can be transferred in a single call.